### PR TITLE
[Composer] Default version is 1.x for now

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -62,7 +62,7 @@ module.exports = function App(resolvers) {
       name: 'composer-scalingo-18',
       stack: 'scalingo-18',
       manifestFile: 'manifest.composer',
-      stableRule: '2.x',
+      stableRule: '1.x',
     }))),
     ruby: new Resolver(new RubySource()),
     python: new Resolver(new PythonSource()),


### PR DESCRIPTION
We will switch to 2.x in a couple of months, when all dependencies are updated

Related to https://github.com/Scalingo/php-buildpack/issue/168