### PR TITLE
Revert "[Composer] Default version is 1.x for now"

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -62,7 +62,7 @@ module.exports = function App(resolvers) {
       name: 'composer-scalingo-18',
       stack: 'scalingo-18',
       manifestFile: 'manifest.composer',
-      stableRule: '1.x',
+      stableRule: '2.x',
     }))),
     ruby: new Resolver(new RubySource()),
     python: new Resolver(new PythonSource()),


### PR DESCRIPTION
Reverts Scalingo/semver.io#10

Related to https://github.com/Scalingo/documentation/pull/1149 and https://github.com/Scalingo/php-buildpack/issues/168

We want to default to Composer 2.x. When we configured Composer 1.x we wanted to default to version 2 a couple of months after. Here we are :) 