### PR TITLE
fix(php-buildpack): set default PHP version to 8.1 for scalingo-20

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -66,7 +66,7 @@ module.exports = function App(resolvers) {
       name: 'php-scalingo-20',
       stack: 'scalingo-20',
       manifestType: "php",
-      stableRule: '~8.0',
+      stableRule: '~8.1',
     }))),
     "php-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
       name: 'php-scalingo-18',


### PR DESCRIPTION
Related to https://github.com/Scalingo/php-buildpack/issues/330