### PR TITLE
fix: add support for Nginx on scalingo-20-minimal

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -36,11 +36,17 @@ module.exports = function App(resolvers) {
       name: 'nginx-scalingo-22-minimal',
       stack: 'scalingo-22-minimal',
       manifestType: "nginx",
-      stableRule: '~1.24',
+      stableRule: '~1.26',
     }))),
     "nginx-scalingo-22": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
       name: 'nginx-scalingo-22',
       stack: 'scalingo-22',
+      manifestType: "nginx",
+      stableRule: '~1.26',
+    }))),
+    "nginx-scalingo-20-minimal": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+      name: 'nginx-scalingo-20-minimal',
+      stack: 'scalingo-20-minimal',
       manifestType: "nginx",
       stableRule: '~1.26',
     }))),


### PR DESCRIPTION
Related to https://github.com/Scalingo/nginx-buildpack/issues/60