### PR TITLE
fix(nodejs) Node inventory switched from 'releases' to 'artifacts'

### DIFF
--- a/lib/sources/node.js
+++ b/lib/sources/node.js
@@ -48,7 +48,7 @@ NodeSource.prototype._parse = function(body) {
     return false;
   }
 
-  const versions = inventory.releases.map(obj => obj.version);
+  const versions = inventory.artifacts.map(obj => obj.version);
 
   this.all = versions.sort(semver.compare);
   this.stable = versions.filter(isStable);


### PR DESCRIPTION
Related to INC-405