### PR TITLE
Deploy to production 2025-09-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ These named routes are also provided for convenience (for each source):
 ### Install project dependencies
 
 ```shell
-docker-compose run --rm web yarn install
+docker compose run --rm web yarn install
 ```
 
 ### Run the service
 
 ```shell
-docker-compose up
+docker compose up
 ```

--- a/README.md
+++ b/README.md
@@ -13,12 +13,9 @@ semver.scalingo.com is a plaintext and JSON webservice that tracks all available
 - [yarn](/yarn/versions)
 
 It also supports Scalingo Stacks for `nginx`, `php` and `composer`:
-- [nginx-scalingo-18](/nginx-scalingo-18/versions)
-- [nginx-scalingo-20](/nginx-scalingo-20/versions)
-- [php-scalingo-18](/php-scalingo-18/versions)
-- [php-scalingo-20](/php-scalingo-20/versions)
-- [composer-scalingo-18](/composer-scalingo-18/versions)
-- [composer-scalingo-20](/composer-scalingo-20/versions)
+- Nginx: `/nginx-${stack}/versions`
+- PHP: `/php-${stack}/versions`
+- Composer: `/composer-${stack}/versions`
 
 It uses that version info to resolve
 [semver range queries](https://docs.npmjs.com/about-semantic-versioning).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     image: "node:16"

--- a/lib/app.js
+++ b/lib/app.js
@@ -32,67 +32,68 @@ module.exports = function App(resolvers) {
   }
 
   var resolvers = resolvers || {
-    "nginx-scalingo-22-minimal": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "nginx-scalingo-22-minimal": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'nginx-scalingo-22-minimal',
       stack: 'scalingo-22-minimal',
       manifestType: "nginx",
       stableRule: '~1.28',
     }))),
-    "nginx-scalingo-22": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "nginx-scalingo-22": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'nginx-scalingo-22',
       stack: 'scalingo-22',
       manifestType: "nginx",
       stableRule: '~1.28',
     }))),
-    "nginx-scalingo-20-minimal": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "nginx-scalingo-20-minimal": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'nginx-scalingo-20-minimal',
       stack: 'scalingo-20-minimal',
       manifestType: "nginx",
       stableRule: '~1.26',
     }))),
-    "nginx-scalingo-20": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "nginx-scalingo-20": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'nginx-scalingo-20',
       stack: 'scalingo-20',
       manifestType: "nginx",
       stableRule: '~1.26',
     }))),
-    "nginx-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "nginx-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'nginx-scalingo-18',
       stack: 'scalingo-18',
       manifestType: "nginx",
       stableRule: '~1.20',
     }))),
-    "php-scalingo-22": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "php-scalingo-22": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'php-scalingo-22',
       stack: 'scalingo-22',
       manifestType: "php",
       stableRule: '~8.1',
+      legacyRule: '< 8.1',
     }))),
-    "php-scalingo-20": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "php-scalingo-20": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'php-scalingo-20',
       stack: 'scalingo-20',
       manifestType: "php",
       stableRule: '~8.1',
     }))),
-    "php-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "php-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'php-scalingo-18',
       stack: 'scalingo-18',
       manifestType: "php",
       stableRule: '~7.4',
     }))),
-    "composer-scalingo-22": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "composer-scalingo-22": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'composer-scalingo-22',
       stack: 'scalingo-22',
       manifestType: 'composer',
       stableRule: '2.x',
     }))),
-    "composer-scalingo-20": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "composer-scalingo-20": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'composer-scalingo-20',
       stack: 'scalingo-20',
       manifestType: 'composer',
       stableRule: '2.x',
     }))),
-    "composer-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
+    "composer-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'composer-scalingo-18',
       stack: 'scalingo-18',
       manifestFile: 'composer',

--- a/lib/app.js
+++ b/lib/app.js
@@ -72,7 +72,7 @@ module.exports = function App(resolvers) {
       name: 'php-scalingo-24',
       stack: 'scalingo-24',
       manifestType: "php",
-      stableRule: '~8.1',
+      stableRule: '~8.4',
     }))),
     "php-scalingo-22": new Resolver(new ScalingoManifestSource(_.merge(manifestBaseOptions, {
       name: 'php-scalingo-22',

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -62,10 +62,15 @@ Resolver.prototype.getUpdatedTime = function () {
   return this.source.updated;
 };
 
-Resolver.prototype.satisfy = function(range) {
+Resolver.prototype.satisfy = function (range, includeLegacy) {
   if (!semver.validRange(range)) return this.getLatestStable();
 
-  return  semver.maxSatisfying(this.getStableVersions(), range) ||
-          semver.maxSatisfying(this.getAllVersions(), range) ||
-          this.getLatestStable();
+  var versions = this.getAllVersions();
+  if (includeLegacy != "true") {
+    versions = _.difference(versions, this.getLegacyVersions());
+  }
+
+  return semver.maxSatisfying(this.getStableVersions(), range) ||
+    semver.maxSatisfying(versions, range) ||
+    this.getLatestStable();
 };

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -11,7 +11,7 @@ function Resolver(source) {
   this.source = source;
 }
 
-Resolver.prototype.update = function(done) {
+Resolver.prototype.update = function (done) {
   log({ message: 'resolving', source: this.source.name });
   this.source.update(onUpdate.bind(this));
 
@@ -21,16 +21,16 @@ Resolver.prototype.update = function(done) {
   }
 };
 
-Resolver.prototype.start = function(frequency) {
+Resolver.prototype.start = function (frequency) {
   this.frequency = frequency;
   this._poll();
 };
 
-Resolver.prototype.stop = function() {
+Resolver.prototype.stop = function () {
   this.frequency = 0;
 };
 
-Resolver.prototype._poll = function() {
+Resolver.prototype._poll = function () {
   if (this.frequency === 0) return;
 
   this.update(function onUpdate(err, success) {
@@ -38,23 +38,27 @@ Resolver.prototype._poll = function() {
   }.bind(this));
 };
 
-Resolver.prototype.getLatest = function() {
+Resolver.prototype.getLatest = function () {
   return _.last(this.source.all);
 };
 
-Resolver.prototype.getLatestStable = function() {
+Resolver.prototype.getLatestStable = function () {
   return _.last(this.getStableVersions());
 };
 
-Resolver.prototype.getAllVersions = function() {
+Resolver.prototype.getAllVersions = function () {
   return this.source.all;
 };
 
-Resolver.prototype.getStableVersions = function() {
+Resolver.prototype.getLegacyVersions = function () {
+  return this.source.legacy || [];
+};
+
+Resolver.prototype.getStableVersions = function () {
   return this.source.stable;
 };
 
-Resolver.prototype.getUpdatedTime = function() {
+Resolver.prototype.getUpdatedTime = function () {
   return this.source.updated;
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -14,6 +14,7 @@ module.exports = function createRouter(resolver) {
     .get('/resolve/:range', typeText, sendSatisfyParams)
     .get('/resolve', typeText, sendSatisfyQuery)
     .get('/stable', typeText, sendStable)
+    .get('/legacy', typeText, sendLegacyVersions)
     .get('/unstable', typeText, sendUnstable)
     .get('/versions', typeText, sendAllVersions)
 
@@ -29,11 +30,11 @@ module.exports = function createRouter(resolver) {
   }
 
   function sendSatisfyParams(req, res, next) {
-    res.send(resolver.satisfy(req.params.range));
+    res.send(resolver.satisfy(req.params.range, req.query.include_legacy));
   }
 
   function sendSatisfyQuery(req, res, next) {
-    res.send(resolver.satisfy(req.query.range));
+    res.send(resolver.satisfy(req.query.range, req.query.include_legacy));
   }
 
   function sendUnstable(req, res, next) {
@@ -44,6 +45,10 @@ module.exports = function createRouter(resolver) {
     res.send(resolver.getAllVersions().join('\n'));
   }
 
+  function sendLegacyVersions(req, res, next) {
+    res.send(resolver.getLegacyVersions().join('\n'));
+  }
+
   function sendJSON(req, res, next) {
     if (req.params.format !== '.json') return next();
     res.json({
@@ -51,6 +56,7 @@ module.exports = function createRouter(resolver) {
       unstable: resolver.getLatest(),
       all: resolver.getAllVersions(),
       stableVersions: resolver.getStableVersions(),
+      legacyVersions: resolver.getLegacyVersions(),
       updated: resolver.getUpdatedTime()
     });
   }

--- a/lib/sources/php.js
+++ b/lib/sources/php.js
@@ -4,7 +4,7 @@ var agent = require('superagent');
 
 var SEMVER = /Version ([57]+\.[0-9]+\.[0-9]+)/g;
 var TIMEOUT = 20000;
-var NOOP = function() {};
+var NOOP = function () { };
 
 module.exports = PhpSource;
 
@@ -18,26 +18,26 @@ function PhpSource(options) {
   }, options);
 }
 
-PhpSource.prototype.update = function(done) {
+PhpSource.prototype.update = function (done) {
   done = done || NOOP;
 
   agent
     .get(this.url[0])
     .timeout(TIMEOUT)
-    .end(parseResponse(false, function() {
+    .end(parseResponse(false, function () {
       agent.get(this.url[1])
         .timeout(TIMEOUT)
         .end(parseResponse(true).bind(this));
     }.bind(this)).bind(this));
 
   function parseResponse(isDone, cb) {
-    return function(err, res) {
+    return function (err, res) {
       if (err) return done(err, false);
       if (!res.text) return done(new Error('No response'), false);
       if (res.status !== 200) return done(new Error('Bad response'), false);
 
       this._parse(res.text);
-      if(isDone) {
+      if (isDone) {
         done(undefined, true);
       } else {
         cb()
@@ -46,7 +46,7 @@ PhpSource.prototype.update = function(done) {
   }
 };
 
-PhpSource.prototype._parse = function(body) {
+PhpSource.prototype._parse = function (body) {
   var versions = [];
   var version = SEMVER.exec(body);
   do {
@@ -57,7 +57,7 @@ PhpSource.prototype._parse = function(body) {
   this.all = _.unique(this.all.concat(versions).sort(semver.compare));
   this.stable = this.all.filter(function (version) {
     return semver.satisfies(version, '>=5.6.x') ||
-              semver.satisfies(version, '>=7.0.x')
+      semver.satisfies(version, '>=7.0.x')
   });
   this.updated = new Date();
 };

--- a/lib/sources/scalingo-manifest.js
+++ b/lib/sources/scalingo-manifest.js
@@ -13,8 +13,10 @@ function ScalingoManifestSource(options) {
     name: options.name,
     url: [`${options.baseURLs[options.manifestType]}/${options.stack}/manifest.${options.manifestType}`],
     stableRule: options.stableRule,
+    legacyRule: options.legacyRule,
     all: [],
     stable: [],
+    legacy: [],
     updated: undefined
   }, options);
 }
@@ -48,7 +50,14 @@ ScalingoManifestSource.prototype._parse = function (body) {
   versions = _.unique(versions).filter(semver.valid);
 
   this.all = _.unique(this.all.concat(versions).sort(semver.compare));
-  if(this.stableRule) {
+  if (this.legacyRule) {
+    self = this
+    this.legacy = this.all.filter(function (version) {
+      return semver.satisfies(version, self.legacyRule)
+    });
+  }
+
+  if (this.stableRule) {
     self = this
     this.stable = this.all.filter(function (version) {
       return semver.satisfies(version, self.stableRule)

--- a/lib/sources/scalingo-manifest.js
+++ b/lib/sources/scalingo-manifest.js
@@ -4,7 +4,7 @@ var agent = require('superagent');
 
 var SEMVER = /([0-9]+\.[0-9]+\.[0-9]+)/g;
 var TIMEOUT = 20000;
-var NOOP = function() {};
+var NOOP = function () { };
 
 module.exports = ScalingoManifestSource;
 
@@ -19,7 +19,7 @@ function ScalingoManifestSource(options) {
   }, options);
 }
 
-ScalingoManifestSource.prototype.update = function(done) {
+ScalingoManifestSource.prototype.update = function (done) {
   done = done || NOOP;
 
   agent
@@ -39,7 +39,7 @@ ScalingoManifestSource.prototype.update = function(done) {
   }
 };
 
-ScalingoManifestSource.prototype._parse = function(body) {
+ScalingoManifestSource.prototype._parse = function (body) {
   var versions = [];
   var version = SEMVER.exec(body);
   do {

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,11 @@ errs@^0.3.2:
   resolved "https://registry.yarnpkg.com/errs/-/errs-0.3.2.tgz#798099b2dbd37ca2bc749e538a7c1307d0b50499"
   integrity sha512-r+/tydov04FSwTi+PrGd0IdY195Y1jZW2g27TJ+cErU8vvr9V4hHYxtRF8bMjv4zYEhap7wK7zBQ2i99LRo6kA==
 
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -580,10 +585,11 @@ function-bind@^1.1.2:
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz#281b7622971123e1ef4b3c90fd7539306da93f3b"
-  integrity sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
+  integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
   dependencies:
+    es-errors "^1.3.0"
     function-bind "^1.1.2"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,9 +1123,9 @@ oauth-sign@~0.9.0:
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-inspect@^1.9.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
-  integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
+  integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
 on-finished@2.4.1:
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,18 +613,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
-  integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
-  dependencies:
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
-    has-proto "^1.0.1"
-    has-symbols "^1.0.3"
-    hasown "^2.0.0"
-
-get-intrinsic@^1.2.4:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.4:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -700,22 +689,12 @@ has-property-descriptors@^1.0.2:
   dependencies:
     es-define-property "^1.0.0"
 
-has-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
-  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
-
-has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
-  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
 has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
-hasown@^2.0.0, hasown@^2.0.2:
+hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,11 +1172,13 @@ proxy-addr@~2.0.7:
     ipaddr.js "1.9.1"
 
 psl@^1.1.28, psl@^1.1.33:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
-  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,9 +647,9 @@ has-symbols@^1.0.3:
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 hasown@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
-  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,6 +153,14 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
 call-bind@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
@@ -318,14 +326,14 @@ debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-define-data-property@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
-  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
+define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
   dependencies:
-    get-intrinsic "^1.2.1"
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
     gopd "^1.0.1"
-    has-property-descriptors "^1.0.0"
 
 delayed-stream@0.0.5:
   version "0.0.5"
@@ -356,6 +364,15 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
   integrity sha512-VzVc42hMZbYU9Sx/ltb7KYuQ6pqAw+cbFWVy4XKdkuEL2CFaRLGEnISPs7YdzaUGpi+CpIqvRmu7hPQ4T7EQ5w==
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
 
 duplexer@~0.1.1:
   version "0.1.2"
@@ -390,7 +407,7 @@ errs@^0.3.2:
   resolved "https://registry.yarnpkg.com/errs/-/errs-0.3.2.tgz#798099b2dbd37ca2bc749e538a7c1307d0b50499"
   integrity sha512-r+/tydov04FSwTi+PrGd0IdY195Y1jZW2g27TJ+cErU8vvr9V4hHYxtRF8bMjv4zYEhap7wK7zBQ2i99LRo6kA==
 
-es-define-property@^1.0.0:
+es-define-property@^1.0.0, es-define-property@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
@@ -399,6 +416,13 @@ es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -589,7 +613,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
   integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
@@ -599,6 +623,30 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
     hasown "^2.0.0"
+
+get-intrinsic@^1.2.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -622,6 +670,11 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
@@ -640,7 +693,7 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
-has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.1:
+has-property-descriptors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
   integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
@@ -657,7 +710,12 @@ has-symbols@^1.0.3:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
-hasown@^2.0.0:
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+hasown@^2.0.0, hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
@@ -953,6 +1011,11 @@ marked@^4.0.17:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -1383,15 +1446,16 @@ serve-static@1.15.0:
     send "0.18.0"
 
 set-function-length@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.0.tgz#2f81dc6c16c7059bda5ab7c82c11f03a515ed8e1"
-  integrity sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
   dependencies:
-    define-data-property "^1.1.1"
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.2"
+    get-intrinsic "^1.2.4"
     gopd "^1.0.1"
-    has-property-descriptors "^1.0.1"
+    has-property-descriptors "^1.0.2"
 
 setprototypeof@1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,11 @@ errs@^0.3.2:
   resolved "https://registry.yarnpkg.com/errs/-/errs-0.3.2.tgz#798099b2dbd37ca2bc749e538a7c1307d0b50499"
   integrity sha512-r+/tydov04FSwTi+PrGd0IdY195Y1jZW2g27TJ+cErU8vvr9V4hHYxtRF8bMjv4zYEhap7wK7zBQ2i99LRo6kA==
 
+es-define-property@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
 es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
@@ -636,11 +641,11 @@ har-validator@~5.1.3:
     har-schema "^2.0.0"
 
 has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz#52ba30b6c5ec87fd89fa574bc1c39125c6f65340"
-  integrity sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
   dependencies:
-    get-intrinsic "^1.2.2"
+    es-define-property "^1.0.0"
 
 has-proto@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,9 +81,9 @@ aws-sign2@~0.7.0:
   integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
 
 aws4@^1.8.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
-  integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
+  integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,14 +161,13 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
-call-bind@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
-  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
+call-bound@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
   dependencies:
-    function-bind "^1.1.2"
-    get-intrinsic "^1.2.1"
-    set-function-length "^1.1.1"
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -326,15 +325,6 @@ debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-define-data-property@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
-  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
-  dependencies:
-    es-define-property "^1.0.0"
-    es-errors "^1.3.0"
-    gopd "^1.0.1"
-
 delayed-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-0.0.5.tgz#d4b1f43a93e8296dfe02694f4680bc37a313c73f"
@@ -407,7 +397,7 @@ errs@^0.3.2:
   resolved "https://registry.yarnpkg.com/errs/-/errs-0.3.2.tgz#798099b2dbd37ca2bc749e538a7c1307d0b50499"
   integrity sha512-r+/tydov04FSwTi+PrGd0IdY195Y1jZW2g27TJ+cErU8vvr9V4hHYxtRF8bMjv4zYEhap7wK7zBQ2i99LRo6kA==
 
-es-define-property@^1.0.0, es-define-property@^1.0.1:
+es-define-property@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
@@ -613,7 +603,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.4:
+get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -652,13 +642,6 @@ glob@3.2.11:
     inherits "2"
     minimatch "0.3"
 
-gopd@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
-  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
-  dependencies:
-    get-intrinsic "^1.1.3"
-
 gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
@@ -681,13 +664,6 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
-
-has-property-descriptors@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
-  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
-  dependencies:
-    es-define-property "^1.0.0"
 
 has-symbols@^1.1.0:
   version "1.1.0"
@@ -1175,7 +1151,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-inspect@^1.9.0:
+object-inspect@^1.13.3:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
@@ -1426,31 +1402,50 @@ serve-static@1.15.0:
     parseurl "~1.3.3"
     send "0.18.0"
 
-set-function-length@^1.1.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
-  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
-  dependencies:
-    define-data-property "^1.1.4"
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
-    get-intrinsic "^1.2.4"
-    gopd "^1.0.1"
-    has-property-descriptors "^1.0.2"
-
 setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-side-channel@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
-  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+side-channel-list@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"
+  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
   dependencies:
-    call-bind "^1.0.0"
-    get-intrinsic "^1.0.2"
-    object-inspect "^1.9.0"
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+
+side-channel-map@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
+  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+
+side-channel-weakmap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz#11dda19d5368e40ce9ec2bdc1fb0ecbc0790ecea"
+  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+    side-channel-map "^1.0.1"
+
+side-channel@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
+  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+    side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
 
 sigmund@~1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,9 +664,9 @@ hawk@1.1.1:
     sntp "0.2.x"
 
 highlight.js@^11.5.1:
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.9.0.tgz#04ab9ee43b52a41a047432c8103e2158a1b8b5b0"
-  integrity sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==
+  version "11.11.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.11.1.tgz#fca06fa0e5aeecf6c4d437239135fabc15213585"
+  integrity sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==
 
 hoek@0.9.x:
   version "0.9.1"


### PR DESCRIPTION
- **chore(deps): bump get-intrinsic from 1.2.2 to 1.2.4**
- **chore(deps): bump hasown from 2.0.0 to 2.0.2**
- **build(docker-compose): remove deprecated version field**
- **docs(readme): Docker Compose command no longer contains a `-`**
- **chore(deps): bump has-property-descriptors from 1.0.1 to 1.0.2**
- **docs(readme): remove list of stacks**
- **chore(deps): bump set-function-length from 1.2.0 to 1.2.2**
- **Lint**
- **[STORY-2508] Add notion of legacy version with specific rule for php-scalingo-22**
- **chore(deps): bump object-inspect from 1.13.1 to 1.13.4**
- **chore(deps): bump psl from 1.9.0 to 1.15.0**
- **chore(deps): bump aws4 from 1.12.0 to 1.13.2**
- **chore(deps): bump highlight.js from 11.9.0 to 11.11.1**
- **chore(deps): bump get-intrinsic from 1.2.2 to 1.3.0**
- **chore(deps): bump side-channel from 1.0.4 to 1.1.0**
- **fix(php-scalingo-24): stable version is 8.4.x**
