### PR TITLE
Update defaults

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -57,12 +57,6 @@ module.exports = function App(resolvers) {
       manifestType: "nginx",
       stableRule: '~1.26',
     }))),
-    "nginx-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
-      name: 'nginx-scalingo-18',
-      stack: 'scalingo-18',
-      manifestType: "nginx",
-      stableRule: '~1.20',
-    }))),
     "php-scalingo-24": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'php-scalingo-24',
       stack: 'scalingo-24',
@@ -82,12 +76,6 @@ module.exports = function App(resolvers) {
       manifestType: "php",
       stableRule: '~8.1',
     }))),
-    "php-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
-      name: 'php-scalingo-18',
-      stack: 'scalingo-18',
-      manifestType: "php",
-      stableRule: '~7.4',
-    }))),
     "composer-scalingo-24": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'composer-scalingo-24',
       stack: 'scalingo-24',
@@ -104,12 +92,6 @@ module.exports = function App(resolvers) {
       name: 'composer-scalingo-20',
       stack: 'scalingo-20',
       manifestType: 'composer',
-      stableRule: '2.x',
-    }))),
-    "composer-scalingo-18": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
-      name: 'composer-scalingo-18',
-      stack: 'scalingo-18',
-      manifestFile: 'composer',
       stableRule: '2.x',
     }))),
     php: new Resolver(new PhpSource()),

--- a/lib/app.js
+++ b/lib/app.js
@@ -33,9 +33,9 @@ module.exports = function App(resolvers) {
       manifestType: "nginx",
       stableRule: '~1.28',
     }))),
-    "nginx-scalingo-22-minimal": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
-      name: 'nginx-scalingo-22-minimal',
-      stack: 'scalingo-22-minimal',
+    "nginx-scalingo-24-minimal": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
+      name: 'nginx-scalingo-24-minimal',
+      stack: 'scalingo-24-minimal',
       manifestType: "nginx",
       stableRule: '~1.28',
     }))),
@@ -45,15 +45,21 @@ module.exports = function App(resolvers) {
       manifestType: "nginx",
       stableRule: '~1.28',
     }))),
-    "nginx-scalingo-20-minimal": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
-      name: 'nginx-scalingo-20-minimal',
-      stack: 'scalingo-20-minimal',
+    "nginx-scalingo-22-minimal": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
+      name: 'nginx-scalingo-22-minimal',
+      stack: 'scalingo-22-minimal',
       manifestType: "nginx",
-      stableRule: '~1.26',
+      stableRule: '~1.28',
     }))),
     "nginx-scalingo-20": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'nginx-scalingo-20',
       stack: 'scalingo-20',
+      manifestType: "nginx",
+      stableRule: '~1.26',
+    }))),
+    "nginx-scalingo-20-minimal": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
+      name: 'nginx-scalingo-20-minimal',
+      stack: 'scalingo-20-minimal',
       manifestType: "nginx",
       stableRule: '~1.26',
     }))),

--- a/lib/app.js
+++ b/lib/app.js
@@ -73,8 +73,7 @@ module.exports = function App(resolvers) {
       name: 'php-scalingo-22',
       stack: 'scalingo-22',
       manifestType: "php",
-      stableRule: '~8.1',
-      legacyRule: '< 8.1',
+      stableRule: '~8.4',
     }))),
     "php-scalingo-20": new Resolver(new ScalingoManifestSource(_.merge(_.clone(manifestBaseOptions), {
       name: 'php-scalingo-20',


### PR DESCRIPTION
- Remove refs to `scalingo-18`
- Add a (missing) resolver for nginx on `scalingo-24-minimal`
- Set PHP 8.4 as the default version on both `scalingo-22` and `scalingo-24`